### PR TITLE
:sparkles: add checkout to commit-meaning workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Install Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Upstream users are missing the checkout step so adding this to see if that gets fixed. 